### PR TITLE
Add unit tests for cn.iocoder.common.framework.util.DateUtil

### DIFF
--- a/common/common-framework/pom.xml
+++ b/common/common-framework/pom.xml
@@ -74,6 +74,12 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.8.1</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/common/common-framework/src/test/java/cn/iocoder/common/framework/util/DateUtilTest.java
+++ b/common/common-framework/src/test/java/cn/iocoder/common/framework/util/DateUtilTest.java
@@ -1,0 +1,56 @@
+package cn.iocoder.common.framework.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+public class DateUtilTest {
+
+    @Test
+    public void testAddDate() {
+        Assert.assertNull(DateUtil.addDate(0, 0));
+        Assert.assertEquals(new Date(1_778_410_800_000L), DateUtil.addDate(
+                new Date(1_515_585_600_000L), 2, 100));
+    }
+
+    @Test
+    public void testFormat() {
+        Assert.assertEquals("", DateUtil.format(null, null));
+        Assert.assertEquals("2018-01-10:12:00:00", DateUtil.format(
+                new Date(1_515_585_600_000L), "yyyy-MM-dd:HH:mm:ss"));
+    }
+
+    @Test
+    public void testGetDayBegin() {
+        Assert.assertNull(DateUtil.getDayBegin(null));
+        Assert.assertEquals(new Date(1_515_542_400_000L),
+                DateUtil.getDayBegin(new Date(1_515_585_600_000L)));
+    }
+
+    @Test
+    public void testGetDayEnd() {
+        Assert.assertNull(DateUtil.getDayEnd(null));
+        Assert.assertEquals(new Date(1_515_628_799_999L), DateUtil.getDayEnd(
+                new Date(1_515_585_600_000L)));
+    }
+
+    @Test
+    public void testIsBetween() {
+        Assert.assertTrue(DateUtil.isBetween(DateUtil.getDayBegin(),
+                DateUtil.getDayEnd()));
+        Assert.assertFalse(DateUtil.isBetween(
+                DateUtil.getDayBegin(new Date(0L)),
+                DateUtil.getDayEnd(new Date(100_000L))));
+    }
+
+    @Test
+    public void testSetCalender() {
+        final GregorianCalendar calendar = new GregorianCalendar();
+        DateUtil.setCalender(calendar, 2, 30, 50, 0);
+
+        Assert.assertEquals(2, calendar.getTime().getHours());
+        Assert.assertEquals(30, calendar.getTime().getMinutes());
+        Assert.assertEquals(50, calendar.getTime().getSeconds());
+    }
+}


### PR DESCRIPTION
Hi,

I've analysed your code base and noticed that `cn.iocoder.common.framework.util.DateUtil` in the `common` module is not fully tested.

I've written some tests that cover this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests should help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other particular classes that you consider important.